### PR TITLE
Update azure key vault module inputs Fixes #11

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -164,20 +164,24 @@ variable availabilityZones {
 variable azure_secret_rg {
   description = "The name of the resource group in which the resources will be created"
   type        = string
+  default     = ""
 }
 
 variable az_key_vault_authentication {
-  description = "The name of the resource group in which the resources will be created"
+  description = "Whether to use key vault to pass authentication"
   type        = bool
+  default     = false
 }
 
 variable azure_keyvault_name {
   description = "The name of the resource group in which the resources will be created"
   type        = string
+  default     = ""
 }
 
 variable azure_keyvault_secret_name {
   description = "The name of the resource group in which the resources will be created"
   type        = string
+  default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -162,7 +162,7 @@ variable availabilityZones {
 }
 
 variable azure_secret_rg {
-  description = "The name of the resource group in which the resources will be created"
+  description = "The name of the resource group in which the Azure Key Vault exists"
   type        = string
   default     = ""
 }
@@ -173,13 +173,13 @@ variable az_key_vault_authentication {
 }
 
 variable azure_keyvault_name {
-  description = "The name of the resource group in which the resources will be created"
+  description = "The name of the Azure Key Vault to use"
   type        = string
   default     = ""
 }
 
 variable azure_keyvault_secret_name {
-  description = "The name of the resource group in which the resources will be created"
+  description = "The name of the Azure Key Vault secret containing the password"
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -170,7 +170,6 @@ variable azure_secret_rg {
 variable az_key_vault_authentication {
   description = "Whether to use key vault to pass authentication"
   type        = bool
-  default     = false
 }
 
 variable azure_keyvault_name {


### PR DESCRIPTION
sets default values for Azure Key Vault module input variables in order to avoid unnecessary ```plan``` and ```apply``` errors. 

Also updates ```description``` values to more accurately describe the purpose of the inputs.